### PR TITLE
A rename python function for Ubuntu

### DIFF
--- a/cmd/Python/netease_rename.py
+++ b/cmd/Python/netease_rename.py
@@ -1,0 +1,100 @@
+"""
+# Download
+http://music.163.com/song/media/outer/url?id={Song id}.mp3
+
+# Music detail
+http://music.163.com/api/song/detail/?id={Music id}&ids=[{Song id}]
+
+# Function
+Rename Netease mp3 files name
+From: source path/<song id>-<bite size>-<random number>.mp3
+To: dist path/<artist name> - <song title>.mp3
+
+Default source path: $HOME/.cache/netease-cloud-music/CachedSongs
+Default dist path: $HOME/output_music
+"""
+
+import requests
+import json
+import os
+import sys
+import argparse
+import eyed3
+
+
+def detect_netease_music_name(file_path, dist_path):
+    """
+    Rename Netease mp3 files name
+    From: file_path/<song id>-<bite size>-<random number>.mp3
+    To: dist_path/<artist name> - <song title>.mp3
+    """
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
+    }
+    url_base = "http://music.163.com/api/song/detail/?id={}&ids=[{}]"
+
+    if not os.path.exists(dist_path):
+        os.mkdir(dist_path)
+
+    for file_name in os.listdir(file_path):
+        try:
+            song_id = file_name.split("-")[0]
+            url_target = url_base.format(song_id, song_id)
+            resp = requests.get(url_target, headers=headers)
+            rr = json.loads(resp.text)
+
+            tt = eyed3.load(os.path.join(file_path, file_name))
+            tt.tag.title = rr["songs"][0]["name"].replace("\xa0", " ")
+            tt.tag.artist = rr["songs"][0]["artists"][0]["name"]
+            tt.tag.album = rr["songs"][0]["album"]["name"]
+            tt.tag.album_artist = rr["songs"][0]["album"]["artists"][0]["name"]
+            print(
+                "song_id = %s, tt.tag title = %s, artist = %s, album = %s, album_artist = %s"
+                % (
+                    song_id,
+                    tt.tag.title,
+                    tt.tag.artist,
+                    tt.tag.album,
+                    tt.tag.album_artist,
+                )
+            )
+            tt.tag.save()
+        except UnicodeEncodeError as e:
+            print(
+                ">>>> UnicodeEncodeError, try again later: file_name = %s, error = %s"
+                % (file_name, str(e))
+            )
+        except:
+            print(">>>> Some other error happens: file_name = %s" % (file_name))
+        finally:
+            dist_name = (
+                os.path.join(
+                    dist_path,
+                    "%s - %s"
+                    % (tt.tag.artist.replace("/", " "), tt.tag.title.replace("/", " ")),
+                )
+                + ".mp3"
+            )
+            os.rename(os.path.join(file_path, file_name), dist_name)
+
+
+def parse_arguments(argv):
+    HOME_DIR = os.getenv("HOME")
+    default_file_path = os.path.join(HOME_DIR, ".cache/netease-cloud-music/CachedSongs")
+    default_dist_path = os.path.join(HOME_DIR, "output_music")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dist_path", type=str, help="Music output path", default=default_dist_path
+    )
+    parser.add_argument(
+        "--source_path", type=str, help="Music source path", default=default_file_path
+    )
+
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_arguments(sys.argv[1:])
+    print("source = %s, dist = %s" % (args.source_path, args.dist_path))
+    detect_netease_music_name(args.source_path, args.dist_path)

--- a/cmd/Python/netease_rename.py
+++ b/cmd/Python/netease_rename.py
@@ -37,6 +37,9 @@ def detect_netease_music_name(file_path, dist_path):
         os.mkdir(dist_path)
 
     for file_name in os.listdir(file_path):
+        if not file_name.endswith('.mp3'):
+            continue
+
         try:
             song_id = file_name.split("-")[0]
             url_target = url_base.format(song_id, song_id)

--- a/cmd/Python_for_Ubuntu_client/netease_rename.py
+++ b/cmd/Python_for_Ubuntu_client/netease_rename.py
@@ -23,7 +23,7 @@ import eyed3
 import shutil
 
 
-def detect_netease_music_name(file_path, dist_path):
+def detect_netease_music_name(file_path, dist_path, KEEP_SOURCE=True):
     """
     Rename Netease mp3 files name
     From: file_path/<song id>-<bite rate>-<random number>.mp3
@@ -87,8 +87,11 @@ def detect_netease_music_name(file_path, dist_path):
             )
             + ".mp3"
         )
-        # os.rename(os.path.join(file_path, file_name), dist_name)
-        shutil.copyfile(os.path.join(file_path, file_name), dist_name)
+        
+        if KEEP_SOURCE == True:
+            shutil.copyfile(os.path.join(file_path, file_name), dist_name)
+        else:
+            os.rename(os.path.join(file_path, file_name), dist_name)
 
 
 def parse_arguments(argv):

--- a/cmd/Python_for_Ubuntu_client/netease_rename.py
+++ b/cmd/Python_for_Ubuntu_client/netease_rename.py
@@ -3,11 +3,11 @@
 http://music.163.com/song/media/outer/url?id={Song id}.mp3
 
 # Music detail
-http://music.163.com/api/song/detail/?id={Music id}&ids=[{Song id}]
+http://music.163.com/api/song/detail/?id={Song id}&ids=[{Song id}]
 
 # Function
 Rename Netease mp3 files name
-From: source path/<song id>-<bite size>-<random number>.mp3
+From: source path/<song id>-<bite rate>-<random number>.mp3
 To: dist path/<artist name> - <song title>.mp3
 
 Default source path: $HOME/.cache/netease-cloud-music/CachedSongs
@@ -20,12 +20,13 @@ import os
 import sys
 import argparse
 import eyed3
+import shutil
 
 
 def detect_netease_music_name(file_path, dist_path):
     """
     Rename Netease mp3 files name
-    From: file_path/<song id>-<bite size>-<random number>.mp3
+    From: file_path/<song id>-<bite rate>-<random number>.mp3
     To: dist_path/<artist name> - <song title>.mp3
     """
     headers = {
@@ -37,7 +38,13 @@ def detect_netease_music_name(file_path, dist_path):
         os.mkdir(dist_path)
 
     for file_name in os.listdir(file_path):
-        if not file_name.endswith('.mp3'):
+        if not file_name.endswith(".mp3"):
+            continue
+        if not len(file_name.split("-")) == 3:
+            print(
+                ">>>> File %s not in format <song id>-<bite rate>-<random number>.mp3"
+                % (file_name)
+            )
             continue
 
         try:
@@ -67,18 +74,21 @@ def detect_netease_music_name(file_path, dist_path):
                 ">>>> UnicodeEncodeError, try again later: file_name = %s, error = %s"
                 % (file_name, str(e))
             )
+            continue
         except:
             print(">>>> Some other error happens: file_name = %s" % (file_name))
-        finally:
-            dist_name = (
-                os.path.join(
-                    dist_path,
-                    "%s - %s"
-                    % (tt.tag.artist.replace("/", " "), tt.tag.title.replace("/", " ")),
-                )
-                + ".mp3"
+            continue
+
+        dist_name = (
+            os.path.join(
+                dist_path,
+                "%s - %s"
+                % (tt.tag.artist.replace("/", " "), tt.tag.title.replace("/", " ")),
             )
-            os.rename(os.path.join(file_path, file_name), dist_name)
+            + ".mp3"
+        )
+        # os.rename(os.path.join(file_path, file_name), dist_name)
+        shutil.copyfile(os.path.join(file_path, file_name), dist_name)
 
 
 def parse_arguments(argv):

--- a/cmd/Python_for_Ubuntu_client/readme.md
+++ b/cmd/Python_for_Ubuntu_client/readme.md
@@ -1,0 +1,51 @@
+# 网易云音乐缓存重命名
+
+## 功能
+- 重命名 mp3 文件，查找 song id 对应的 `歌手名` 与 `歌曲名`，并将文件重命名为 `歌手名 - 歌曲名.mp3`
+  ```md
+  From: source path/<song id>-<bite rate>-<random number>.mp3
+  To: dist path/<artist name> - <song title>.mp3
+  ```
+## 使用说明示例
+- 在 Ubuntu 上使用网易云音乐的客户端，其缓存直接是 mp3 文件，缓存在 `~/.cache/netease-cloud-music/CachedSongs/`
+  ```shell
+  $ ls ~/.cache/netease-cloud-music/CachedSongs/ -1
+  1609689-320-b70d1d38edd3f443bc503f592fc440ed.mp3
+  25638306-320-3d42ddad5384518bbbf8bc68fff4cdfa.mp3
+  4254253-128-1fb4ae7055ea4ceb36862f6228e61aa4.mp3
+  441116287-128-0d15579de47acbe4c8177e54ba43bf4b.mp3
+  ```
+- 因此主要需要的是重命名，使用如下
+  ```shell
+  $ python netease_rename.py
+  source = ~/.cache/netease-cloud-music/CachedSongs, dist = ~/output_music
+  song_id = 25638306, tt.tag title = ありがとう…, artist = KOKIA, album = ありがとう…, album_artist = KOKIA
+  song_id = 441116287, tt.tag title = 茜さす, artist = Aimer, album = 茜さす/everlasting snow, album_artist = Aimer
+  song_id = 4254253, tt.tag title = Mustang cabriolet, artist = Paris Brune, album = L’œil du cyclone, album_artist = Paris Brune
+  song_id = 1609689, tt.tag title = Vale Of Tears, artist = Jay Clifford, album = Silver Tomb For The Kingfisher, album_artist = Jay Clifford
+  ```
+- 输出
+  ```shell
+  $ ls ~/output_music/ -1
+  'Aimer - 茜さす.mp3'
+  'Jay Clifford - Vale Of Tears.mp3'
+  'KOKIA - ありがとう….mp3'
+  'Paris Brune - Mustang cabriolet.mp3'
+  ```
+## 参数
+- `--dist_path` 输出路径，默认 `$HOME/output_music`
+- `--source_path` 输入文件夹路径，缓存文件地址，默认 `$HOME/.cache/netease-cloud-music/CachedSongs`
+- `--help` 帮助信息
+## 依赖
+- **eyed3** mp3 文件属性赋值，如 title / artist / album / album_artist
+  ```shell
+  $ pip install eyed3
+  ```
+- **requests** 网页请求
+  ```shell
+  $ pip install requests
+  ```
+- **shutil** 文件复制
+  ```shell
+  $ pip install shutil
+  ```


### PR DESCRIPTION
Hi,

很不错的程序，尤其是解密的部分 :D

写了一个小程序，用于将 Ubuntu 上网易云音乐的缓存文件重命名成真实的名字，看看能不能用上
```md
From: source path/<song id>-<bite size>-<random number>.mp3
To: dist path/<artist name> - <song title>.mp3
```

在 Ubuntu 上使用网易云音乐的客户端，其缓存直接是 mp3 文件，缓存在 `~/.cache/netease-cloud-music/CachedSongs/`
```shell
$ ls ~/.cache/netease-cloud-music/CachedSongs/ -1
1609689-320-b70d1d38edd3f443bc503f592fc440ed.mp3
25638306-320-3d42ddad5384518bbbf8bc68fff4cdfa.mp3
4254253-128-1fb4ae7055ea4ceb36862f6228e61aa4.mp3
441116287-128-0d15579de47acbe4c8177e54ba43bf4b.mp3
```
因此主要需要的是重命名，使用如下
```shell
$ python netease_rename.py 
source = /home/leondgarse/.cache/netease-cloud-music/CachedSongs, dist = /home/leondgarse/output_music
song_id = 25638306, tt.tag title = ありがとう…, artist = KOKIA, album = ありがとう…, album_artist = KOKIA
song_id = 441116287, tt.tag title = 茜さす, artist = Aimer, album = 茜さす/everlasting snow, album_artist = Aimer
song_id = 4254253, tt.tag title = Mustang cabriolet, artist = Paris Brune, album = L’œil du cyclone, album_artist = Paris Brune
song_id = 1609689, tt.tag title = Vale Of Tears, artist = Jay Clifford, album = Silver Tomb For The Kingfisher, album_artist = Jay Clifford
```
输出
```shell
$ ls ~/output_music/ -1
'Aimer - 茜さす.mp3'
'Jay Clifford - Vale Of Tears.mp3'
'KOKIA - ありがとう….mp3'
'Paris Brune - Mustang cabriolet.mp3'
```

**参数**
- `--dist_path` 输出路径，默认 `$HOME/output_music`
- `--source_path` 输入文件夹路径，缓存文件地址，默认 `$HOME/.cache/netease-cloud-music/CachedSongs`

**依赖**
- eyed3，mp3 文件属性赋值，如 title / artist / album / album_artist
  ```shell
  pip install eyed3
  ```